### PR TITLE
Change the 'main' file location

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "mocha" : "0.8.x",
     "uglify-js" : "1.2.5"
   },
-  "main": "lib/twix",
+  "main": "bin/twix",
   "test": "make test",
   "engines": {
     "node": "*"


### PR DESCRIPTION
This allows twix to be correctly required in node. Before `require('twix')` would result in:

```
Error: Cannot find module 'twix'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
```
