### PR TITLE
Add intersection() + rename merge() to union()

### DIFF
--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -275,6 +275,7 @@ class Twix
   daysIn: (minHours) -> @iterate 'days', minHours
   past: -> @isPast()
   duration: -> @humanizeLength()
+  merge: (other) -> @union other
 
   # -- INTERNAL
   _trueStart: -> if @allDay then @start.clone().startOf("day") else @start

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -589,6 +589,10 @@ describe "engulfs()", ->
     it "returns true for an engulfing event", ->
       assertNotEngulfing someDays, new Twix("1982-5-22", "1982-5-28", true)
 
+describe "merge()", ->
+  it "calls union()", ->
+    assertTwixEqual new Twix("1982-5-24", "1982-5-26"), new Twix("1982-5-24", "1982-5-25").merge(new Twix("1982-5-25", "1982-5-26"))
+
 describe "union()", ->
 
   someTime = thatDay "5:30", "8:30"


### PR DESCRIPTION
Twix.js already implements merge(). Merge is in fact the [union](http://en.wikipedia.org/wiki/Union_%28set_theory%29) between two ranges.
Next logical step is to add intersection().
intersection() computes the [intersection](http://en.wikipedia.org/wiki/Intersection_%28set_theory%29) between two ranges.

Why having intersection() is interesting? in order to achieve this (screenshot from Google Calendar):

![Google Calendar](http://img11.hostingpics.net/pics/924040ScreenShot20130427at101217PM.png)

Example:
The intersection between "Mon Apr 29" (`new Twix("2013-04-29", "2013-04-29", true)`) and the event "Switch End-to-end [...] review" (`new Twix("2013-04-29 14:00", "2013-04-29 15:00", false)`) is "2:00pm - 3:00pm".
