### PR TITLE
bumped component dep to master

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "twix",
   "version": "0.2.2",
   "dependencies": {
-    "timrwood/moment": "develop"
+    "timrwood/moment": "*"
   },
   "scripts": ["bin/twix.js"],
   "main": "bin/twix.js",


### PR DESCRIPTION
Moment pushed 2.1.0 to master. This included moving component.json to the master.

This change reflects that. 

Would be great to see this merged into master (twix.js).

Thanks!
