### PR TITLE
bower.json: depend on moment js instead of moment

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "twix",
   "version": "0.4.0",
   "dependencies": {
-    "moment": "*"
+    "momentjs": "*"
   },
   "main": "bin/twix.js",
   "description": "A date range plugin for moment.js"


### PR DESCRIPTION
http://momentjs.com lists `momentjs` as the official package, and other packages (like moment-range) depend on `momentjs`, not `moment`. Make this consistent to prevent Bower from installing multiple versions of Moment.js when both packages are listed as dependencies.
