### PR TITLE
add failing test for all-day endpoint

### DIFF
--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -602,11 +602,17 @@ test = (moment, Twix) ->
       it "returns true for moments at the end of the range", ->
         assertEqual true, range.contains(start.clone().endOf "day")
 
-      it "returns false for moments before the range", ->
+      it "returns false for moments well before the range", ->
         assertEqual false, range.contains(thisYear "05-24")
 
-      it "returns false for moments after the range", ->
-        assertEqual false, range.contains(thisYear "05-26", "00:00:01")
+      it "returns false for moments immediately before the range", ->
+        assertEqual false, range.contains(thisYear("05-24").endOf("day"))
+
+      it "returns false for moments immediately after the range", ->
+        assertEqual false, range.contains(thisYear "05-26")
+
+      it "returns false for moments well after the range", ->
+        assertEqual false, range.contains(thisYear "05-27")
 
   describe "overlaps()", ->
 


### PR DESCRIPTION
@icambron, exactly as you suspected, including midnight of the next day in all day ranges is breaking some of our code. Since you mentioned that the change makes Twix more consistent and its code simpler, this PR only adds a failing test.

But basically, it seems like the following shouldn't be true:

``` js
moment.twix("2013-04-12", "2013-04-12", true).contains("2013-04-13")
```

Let me know if I can help with this at all!
