### PR TITLE
Fix iterate method.

### DIFF
--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -108,7 +108,7 @@ makeTwix = (moment) ->
 
       start = @_trueStart.clone().startOf period
       end = @_trueEnd.clone().startOf period
-      hasNext = => (!@allDay && start <= end && (!minHours || !start.isSame(end) || @end.hours() > minHours)) || (@allDay && start < end)
+      hasNext = => (start <= end && (!minHours || !start.isSame(end) || @end.hours() > minHours || @allDay))
 
       @_iterateHelper period, start, hasNext, intervalAmount
 


### PR DESCRIPTION
As posted on https://github.com/icambron/twix.js/commit/7ae3af371529b6337a2c07a012aa2c7c7be60f28#commitcomment-8091275

> This is a breaking change in the way #iterate behaves with all day ranges. It is now also inconsistent with #count.
> # iterateInner (and #countInner) already show the behavior #iterate has now been broken to show, so why was this change needed at all?

This reverts this breaking change. If the change was intentional, I'm curious about the reason.
