### PR TITLE
Meteor integration fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-#Twix
+# Twix
 
 [![NPM version][npm-version-image]][npm-url] [![NPM downloads][npm-downloads-image]][npm-url] [![MIT License][license-image]][license-url] [![Build Status][travis-image]][travis-url]
 
@@ -19,11 +19,11 @@ t.count("days"); //=> 1
 
 And much more.
 
-##[Documentation](http://icambron.github.io/twix.js/docs.html)
+## [Documentation](http://icambron.github.io/twix.js/docs.html)
 
 **Breaking change in 0.6.0** Twix ranges will ignore changes to their endpoints; once you create the range, it's frozen in place. Construct new ranges to grow/shrink.
 
-##Building##
+## Building
 
 If you want to build Twix for yourself, you'll need to install CoffeeScript. Then clone the repo out and run this:
 
@@ -37,14 +37,14 @@ Note that the source is `src/twix.coffee`; the output is `bin/twix.js`. You can 
 
 You can also run the tests in-browser by building and then loading `test/test.html`.
 
-##Contributing##
+## Contributing
 
 Patches are welcome!
 
  * Submit pull requests to the `develop` branch. I merge develop to master when we cut a release.
  * Don't include your changes to the generated `.js` files in the patch; they're much harder to merge. I'll generate them when I cut the release.
 
-##Changelog##
+## Changelog
 
  * **0.6.0**: Moment deprecations, s/lang/locale, xor, intersection, split, difference, immutability
 
@@ -64,7 +64,7 @@ Patches are welcome!
 
  * Older versions - wasn't tracking.
 
-##License (MIT)##
+## License (MIT)
 
 Copyright (c) 2012 Isaac Cambron
 

--- a/package.js
+++ b/package.js
@@ -3,6 +3,7 @@ Package.describe({
   summary: "Twix.js (official) by Isaac Cambron: a Moment.js plugin for working with date ranges.",
   version: "0.6.0",
   git: "https://github.com/icambron/twix.js.git",
+  documentation: "README.markdown",
 });
 
 // Makes Twix available both on the server and on the client


### PR DESCRIPTION
Because of recently updates with Meteor@1.0.3.1

1) we now need to specify a documentation file (in case different than `README.md`)
2) a documentation excerpt is extracted taking the section between the first and the second headers within the docs 