### PR TITLE
Don't require CoffeeScript compiler to be installed globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ endif
 VER=$(shell grep version package.json | sed "s/[a-z \":,]*//g")
 
 build: directories
-	@find src -name '*.coffee' | xargs coffee -c -o bin
-	@find test -name '*.coffee' | xargs coffee -c -o test/bin
+	@find src -name '*.coffee' | xargs node_modules/.bin/coffee -c -o bin
+	@find test -name '*.coffee' | xargs node_modules/.bin/coffee -c -o test/bin
 
 	@./node_modules/uglify-js/bin/uglifyjs -o bin/twix.min.js bin/twix.js
 	@./node_modules/uglify-js/bin/uglifyjs -o bin/locale.min.js bin/locale.js

--- a/README.markdown
+++ b/README.markdown
@@ -27,11 +27,11 @@ And much more.
 
 ## Building
 
-If you want to build Twix for yourself, you'll need to install CoffeeScript. Then clone the repo out and run this:
+If you want to build Twix for yourself, clone the repo and run this:
 
     make configure build
 
-Configure just installs the NPMs and brings in Moment as a submodule, so you only have to do that part once.
+Configure just installs the NPMs (including CoffeeScript) and brings in Moment as a submodule, so you only have to do that part once.
 
 Note that the source is `src/twix.coffee`; the output is `bin/twix.js`. You can run the tests via
 


### PR DESCRIPTION
Other folks may not be so persnickety, so feel free to ignore this if you don't think it's valuable.  I just prefer to minimize the number of executables I have to install onto my global `PATH` whenever possible.