### PR TITLE
Add support for half-open ranges

### DIFF
--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -18,7 +18,6 @@ getBounds = (startTwix, endTwix, allDay) ->
     contains = includeStart
   else
     contains = if includeStart then "start" else "end"
-  console.log "includeStart", includeStart, "includeEnd", includeEnd, "contains", contains
 
   start = startTwix.start
   if startTwix.allDay and not allDay
@@ -199,7 +198,6 @@ makeTwix = (moment) ->
         later = if @_trueEnd >= other._trueEnd then this else other
 
       [start, end, contains] = getBounds earlier, later, allDay
-      console.log earlier.containsEndpoints, start.format(), later.containsEndpoints, end.format(), contains
       new Twix(start, end, allDay: allDay, containsEndpoints: contains)
 
     intersection: (other) ->

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -28,12 +28,13 @@ makeTwix = (moment) ->
       @start = moment start, parseFormat, options.parseStrict
       @end = moment end, parseFormat, options.parseStrict
       @allDay = options.allDay ? false
+      @containsEndpoints = options.containsEndpoints ? true
 
       @_trueStart = if @allDay then @start.clone().startOf("day") else @start
-      if options.containEndpoints not in ["start", true, undefined]
+      if @containsEndpoints not in ["start", true]
         @_trueStart = @_trueStart.clone().add(1)
 
-      if options.containEndpoints in ["end", true, undefined]
+      if @containsEndpoints in ["end", true]
         @_trueEnd = if @allDay then @end.clone().startOf("day").add(1, "day") else @end
       else
         @_trueEnd = if @allDay then @end.clone().endOf("day") else @end.clone().subtract(1)

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -263,7 +263,7 @@ makeTwix = (moment) ->
         @end.valueOf() == other.end.valueOf()
 
     # -- FORMATING --
-    toString: -> "{start: #{@start.format()}, end: #{@end.format()}, allDay: #{@allDay ? "true" : "false"}}"
+    toString: -> "{start: #{@start.format()}, end: #{@end.format()}, allDay: #{@allDay ? "true" : "false"}, containsEndpoints: #{@containsEndpoints ? "true" : "false"}}"
 
     simpleFormat: (momentOpts, inopts) ->
       options =

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -30,7 +30,13 @@ makeTwix = (moment) ->
       @allDay = options.allDay ? false
 
       @_trueStart = if @allDay then @start.clone().startOf("day") else @start
-      @_trueEnd = if @allDay then @end.clone().startOf("day").add(1, "day") else @end
+      if options.containEndpoints not in ["start", true, undefined]
+        @_trueStart = @_trueStart.clone().add(1)
+
+      if options.containEndpoints in ["end", true, undefined]
+        @_trueEnd = if @allDay then @end.clone().startOf("day").add(1, "day") else @end
+      else
+        @_trueEnd = if @allDay then @end.clone().endOf("day") else @end.clone().subtract(1)
 
     @_extend: (first, others...) ->
       for other in others

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -30,7 +30,7 @@ makeTwix = (moment) ->
       @allDay = options.allDay ? false
 
       @_trueStart = if @allDay then @start.clone().startOf("day") else @start
-      @_trueEnd = if @allDay then @end.startOf('d').clone().add(1, "day") else @end
+      @_trueEnd = if @allDay then @end.clone().startOf("day").add(1, "day") else @end
 
     @_extend: (first, others...) ->
       for other in others

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -258,6 +258,7 @@ makeTwix = (moment) ->
     equals: (other) ->
       (other instanceof Twix) &&
         @allDay == other.allDay &&
+        @containsEndpoints == other.containsEndpoints &&
         @start.valueOf() == other.start.valueOf() &&
         @end.valueOf() == other.end.valueOf()
 

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -31,7 +31,7 @@ makeTwix = (moment) ->
       @containsEndpoints = options.containsEndpoints ? true
 
       @_trueStart = if @allDay then @start.clone().startOf("day") else @start
-      if @containsEndpoints not in ["start", true]
+      unless @containsEndpoints in ["start", true]
         @_trueStart = @_trueStart.clone().add(1)
 
       if @containsEndpoints in ["end", true]

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -778,7 +778,7 @@ test = (moment, Twix) ->
 
   unionTests = (contains, resultContains) ->
     someTime = thatDay "05:30", "08:30", containsEndpoints: contains
-    someDays = new Twix "1982-05-24", "1982-05-25", allDay: true, containsEndpoints: contains
+    someDays = new Twix "1982-05-24", "1982-05-26", allDay: true, containsEndpoints: contains
 
     describe "union() with containsEndpoints=" + contains, ->
 
@@ -824,53 +824,53 @@ test = (moment, Twix) ->
 
         it "spans a later time", ->
           assertTwixEqual(
-            new Twix("1982-05-24 00:00", "1982-05-26 07:00", containsEndpoints: resultContains.later),
-            someDays.union(new Twix("1982-05-24 20:00", "1982-05-26 07:00"))
+            new Twix("1982-05-24 00:00", "1982-05-27 07:00", containsEndpoints: resultContains.later),
+            someDays.union(new Twix("1982-05-24 20:00", "1982-05-27 07:00"))
           )
 
         it "spans an earlier time", ->
           assertTwixEqual(
-            new Twix("1982-05-23 08:00", moment("1982-05-26"), containsEndpoints: resultContains.earlier),
+            new Twix("1982-05-23 08:00", moment("1982-05-27"), containsEndpoints: resultContains.earlier),
             someDays.union(new Twix("1982-05-23 08:00", "1982-05-25 07:00"))
           )
 
         #i'm tempted to just say this is wrong...shouldn't it get to stay an all-day range?
         it "isn't affected by engulfing ranges", ->
           assertTwixEqual(
-            new Twix("1982-05-24 00:00", moment("1982-05-26"), containsEndpoints: contains),
+            new Twix("1982-05-24 00:00", moment("1982-05-27"), containsEndpoints: contains),
             someDays.union(someTime)
           )
 
         it "becomes an engulfing range", ->
           assertTwixEqual(
-            new Twix("1982-05-23 20:00", "1982-05-26 08:30"),
-            someDays.union(new Twix("1982-05-23 20:00", "1982-05-26 08:30"))
+            new Twix("1982-05-23 20:00", "1982-05-27 08:30"),
+            someDays.union(new Twix("1982-05-23 20:00", "1982-05-27 08:30"))
           )
 
       describe "two all-day ranges", ->
 
         it "spans a later time", ->
           assertTwixEqual(
-            new Twix("1982-05-24", "1982-05-28", allDay: true, containsEndpoints: resultContains.later),
-            someDays.union(new Twix("1982-05-27", "1982-05-28", true))
+            new Twix("1982-05-24", "1982-05-29", allDay: true, containsEndpoints: resultContains.later),
+            someDays.union(new Twix("1982-05-28", "1982-05-29", true))
           )
 
         it "spans an earlier time", ->
           assertTwixEqual(
-            new Twix("1982-05-21", "1982-05-25", allDay: true, containsEndpoints: resultContains.earlier),
+            new Twix("1982-05-21", "1982-05-26", allDay: true, containsEndpoints: resultContains.earlier),
             someDays.union(new Twix("1982-05-21", "1982-05-22", true))
           )
 
         it "spans a partially later time", ->
           assertTwixEqual(
-            new Twix("1982-05-24", "1982-05-26", allDay: true, containsEndpoints: resultContains.later),
-            someDays.union(new Twix("1982-05-25", "1982-05-26", true))
+            new Twix("1982-05-24", "1982-05-27", allDay: true, containsEndpoints: resultContains.later),
+            someDays.union(new Twix("1982-05-26", "1982-05-27", true))
           )
 
         it "spans a partially earlier time", ->
           assertTwixEqual(
-            new Twix("1982-05-23", "1982-05-25", allDay: true, containsEndpoints: resultContains.earlier),
-            someDays.union(new Twix("1982-05-23", "1982-05-25", true))
+            new Twix("1982-05-23", "1982-05-26", allDay: true, containsEndpoints: resultContains.earlier),
+            someDays.union(new Twix("1982-05-23", "1982-05-24", true))
           )
 
         it "isn't affected by engulfing ranges", ->

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -780,7 +780,7 @@ test = (moment, Twix) ->
     someTime = thatDay "05:30", "08:30", containsEndpoints: contains
     someDays = new Twix "1982-05-24", "1982-05-26", allDay: true, containsEndpoints: contains
 
-    describe "union() with containsEndpoints=" + contains, ->
+    describe "with containsEndpoints=#{contains}", ->
 
       describe "non-all-day ranges", ->
 
@@ -879,10 +879,11 @@ test = (moment, Twix) ->
         it "becomes an engulfing range", ->
           assertTwixEqual someDays, thatDay().union(someDays)
 
-  unionTests true,    earlier: true,    later: true
-  unionTests "start", earlier: "start", later: true
-  unionTests "end",   earlier: true,    later: "end"
-  unionTests false,   earlier: "start", later: "end"
+  describe "union()", ->
+    unionTests true,    earlier: true,    later: true
+    unionTests "start", earlier: "start", later: true
+    unionTests "end",   earlier: true,    later: "end"
+    unionTests false,   earlier: "start", later: "end"
 
   describe "intersection()", ->
 

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -60,6 +60,18 @@ test = (moment, Twix) ->
         t = moment("1981-05-25").twix("1982-05-25", allDay: true)
         assertEqual t.allDay, true
 
+      it "creates closed ranges by default", ->
+        t = moment("1981-05-25").twix("05/25/1982", "MM/DD/YYYY")
+        assertEqual t.containsEndpoints, true
+        t = moment("1981-05-25").twix("1982-05-25")
+        assertEqual t.containsEndpoints, true
+
+      it "uses a containsEndpoints option argument", ->
+        t = moment("1981-05-25").twix("05/25/1982", "MM/DD/YYYY", containsEndpoints: false)
+        assertEqual t.containsEndpoints, false
+        t = moment("1981-05-25").twix("1982-05-25", containsEndpoints: false)
+        assertEqual t.containsEndpoints, false
+
     describe "moment.forDuration()", ->
       it "constructs a twix", ->
         from = thisYear("05-25")

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -15,9 +15,9 @@ test = (moment, Twix) ->
   yesterday = -> moment().subtract(1, "day").startOf "day"
   tomorrow = -> moment().add(1, "day").startOf "day"
 
-  thatDay = (start, end) ->
+  thatDay = (start, end, options) ->
     if start
-      moment("1982-05-25T#{start}").twix "1982-05-25T#{end}"
+      moment("1982-05-25T#{start}").twix "1982-05-25T#{end}", options
     else
       moment("1982-05-25").twix "1982-05-25", true
 
@@ -776,67 +776,113 @@ test = (moment, Twix) ->
       it "returns true for an engulfing range", ->
         assertNotEngulfing someDays, new Twix("1982-05-22", "1982-05-28", true)
 
-  describe "union()", ->
+  unionTests = (contains, resultContains) ->
+    someTime = thatDay "05:30", "08:30", containsEndpoints: contains
+    someDays = new Twix "1982-05-24", "1982-05-25", allDay: true, containsEndpoints: contains
 
-    someTime = thatDay "05:30", "08:30"
-    someDays = new Twix "1982-05-24", "1982-05-25", true
+    describe "union() with containsEndpoints=" + contains, ->
 
-    describe "non-all-day ranges", ->
+      describe "non-all-day ranges", ->
 
-      it "spans a later time", ->
-        assertTwixEqual thatDay("05:30", "11:30"), someTime.union(thatDay "09:30", "11:30")
+        it "spans a later time", ->
+          assertTwixEqual(
+            thatDay("05:30", "11:30", containsEndpoints: resultContains.later),
+            someTime.union(thatDay "09:30", "11:30")
+          )
 
-      it "spans an earlier time", ->
-        assertTwixEqual thatDay("03:30", "08:30"), someTime.union(thatDay "03:30", "04:30")
+        it "spans an earlier time", ->
+          assertTwixEqual(
+            thatDay("03:30", "08:30", containsEndpoints: resultContains.earlier),
+            someTime.union(thatDay "03:30", "04:30")
+          )
 
-      it "spans a partially later range", ->
-        assertTwixEqual thatDay("05:30", "11:30"), someTime.union(thatDay "08:00", "11:30")
+        it "spans a partially later range", ->
+          assertTwixEqual(
+            thatDay("05:30", "11:30", containsEndpoints: resultContains.later),
+            someTime.union(thatDay "08:00", "11:30")
+          )
 
-      it "spans a partially earlier range", ->
-        assertTwixEqual thatDay("04:30", "08:30"), someTime.union(thatDay "04:30", "06:30")
+        it "spans a partially earlier range", ->
+          assertTwixEqual(
+            thatDay("04:30", "08:30", containsEndpoints: resultContains.earlier),
+            someTime.union(thatDay "04:30", "06:30")
+          )
 
-      it "isn't affected by engulfed ranges", ->
-        assertTwixEqual someTime, someTime.union(thatDay "06:30", "07:30")
+        it "isn't affected by engulfed ranges", ->
+          assertTwixEqual someTime, someTime.union(thatDay "06:30", "07:30")
 
-      it "becomes an engulfing range", ->
-        assertTwixEqual thatDay("04:30", "09:30"), someTime.union(thatDay "04:30", "09:30")
+        it "becomes an engulfing range", ->
+          assertTwixEqual thatDay("04:30", "09:30"), someTime.union(thatDay "04:30", "09:30")
 
-      it "spans adjacent ranges", ->
-        assertTwixEqual thatDay("05:30", "09:30"), someTime.union(thatDay "08:30", "09:30")
+        it "spans adjacent ranges", ->
+          assertTwixEqual(
+            thatDay("05:30", "09:30", containsEndpoints: resultContains.later),
+            someTime.union(thatDay "08:30", "09:30")
+          )
 
-    describe "one all-day range", ->
-      it "spans a later time", ->
-        assertTwixEqual new Twix("1982-05-24 00:00", "1982-05-26 07:00"), someDays.union(new Twix("1982-05-24 20:00", "1982-05-26 07:00"))
+      describe "one all-day range", ->
 
-      it "spans an earlier time", ->
-        assertTwixEqual new Twix("1982-05-23 08:00", moment("1982-05-26")), someDays.union(new Twix("1982-05-23 08:00", "1982-05-25 07:00"))
+        it "spans a later time", ->
+          assertTwixEqual(
+            new Twix("1982-05-24 00:00", "1982-05-26 07:00", containsEndpoints: resultContains.later),
+            someDays.union(new Twix("1982-05-24 20:00", "1982-05-26 07:00"))
+          )
 
-      #i'm tempted to just say this is wrong...shouldn't it get to stay an all-day range?
-      it "isn't affected by engulfing ranges", ->
-        assertTwixEqual new Twix("1982-05-24 00:00", moment("1982-05-26")), someDays.union(someTime)
+        it "spans an earlier time", ->
+          assertTwixEqual(
+            new Twix("1982-05-23 08:00", moment("1982-05-26"), containsEndpoints: resultContains.earlier),
+            someDays.union(new Twix("1982-05-23 08:00", "1982-05-25 07:00"))
+          )
 
-      it "becomes an engulfing range", ->
-        assertTwixEqual new Twix("1982-05-23 20:00", "1982-05-26 08:30"), someDays.union(new Twix("1982-05-23 20:00", "1982-05-26 08:30"))
+        #i'm tempted to just say this is wrong...shouldn't it get to stay an all-day range?
+        it "isn't affected by engulfing ranges", ->
+          assertTwixEqual(
+            new Twix("1982-05-24 00:00", moment("1982-05-26"), containsEndpoints: contains),
+            someDays.union(someTime)
+          )
 
-    describe "two all-day ranges", ->
+        it "becomes an engulfing range", ->
+          assertTwixEqual(
+            new Twix("1982-05-23 20:00", "1982-05-26 08:30"),
+            someDays.union(new Twix("1982-05-23 20:00", "1982-05-26 08:30"))
+          )
 
-      it "spans a later time", ->
-        assertTwixEqual new Twix("1982-05-24", "1982-05-28", true), someDays.union(new Twix("1982-05-27", "1982-05-28", true))
+      describe "two all-day ranges", ->
 
-      it "spans an earlier time", ->
-        assertTwixEqual new Twix("1982-05-21", "1982-05-25", true), someDays.union(new Twix("1982-05-21", "1982-05-22", true))
+        it "spans a later time", ->
+          assertTwixEqual(
+            new Twix("1982-05-24", "1982-05-28", allDay: true, containsEndpoints: resultContains.later),
+            someDays.union(new Twix("1982-05-27", "1982-05-28", true))
+          )
 
-      it "spans a partially later time", ->
-        assertTwixEqual new Twix("1982-05-24", "1982-05-26", true), someDays.union(new Twix("1982-05-25", "1982-05-26", true))
+        it "spans an earlier time", ->
+          assertTwixEqual(
+            new Twix("1982-05-21", "1982-05-25", allDay: true, containsEndpoints: resultContains.earlier),
+            someDays.union(new Twix("1982-05-21", "1982-05-22", true))
+          )
 
-      it "spans a partially earlier time", ->
-        assertTwixEqual new Twix("1982-05-23", "1982-05-25", true), someDays.union(new Twix("1982-05-23", "1982-05-25", true))
+        it "spans a partially later time", ->
+          assertTwixEqual(
+            new Twix("1982-05-24", "1982-05-26", allDay: true, containsEndpoints: resultContains.later),
+            someDays.union(new Twix("1982-05-25", "1982-05-26", true))
+          )
 
-      it "isn't affected by engulfing ranges", ->
-        assertTwixEqual someDays, someDays.union(thatDay())
+        it "spans a partially earlier time", ->
+          assertTwixEqual(
+            new Twix("1982-05-23", "1982-05-25", allDay: true, containsEndpoints: resultContains.earlier),
+            someDays.union(new Twix("1982-05-23", "1982-05-25", true))
+          )
 
-      it "becomes an engulfing range", ->
-        assertTwixEqual someDays, thatDay().union(someDays)
+        it "isn't affected by engulfing ranges", ->
+          assertTwixEqual someDays, someDays.union(thatDay())
+
+        it "becomes an engulfing range", ->
+          assertTwixEqual someDays, thatDay().union(someDays)
+
+  unionTests true,    earlier: true,    later: true
+  unionTests "start", earlier: "start", later: true
+  unionTests "end",   earlier: true,    later: "end"
+  unionTests false,   earlier: "start", later: "end"
 
   describe "intersection()", ->
 


### PR DESCRIPTION
@icambron  I'm opening this as a very minimal PR because I'd like your feedback on the implementation approach.  If you like what you see here, I'll work on updating the docs and adding some simple tests.

I've added support for an "containEndpoints" configuration option when constructing a new Twix range.  There are four valid values for the containEndpoints option:

- `true`:  construct a fully closed range, where the range contains both its start and end moments
- `"end"`:  construct a half open range, where the range contains its end but not its start moment
- `"start"`:  construct a half open range, where the range contains its start but not its end moment
- `false`:  construct a fully open range that contains neither its start nor end moments

This is implemented by twiddling the values of `_trueStart` and `_trueEnd` in Twix's constructor, minimizing the impact on code complexity.  I haven't tested everything comprehensively yet, but based on some informal testing of various API methods, I feel like the resulting behavior matches my expectations quite nicely — formatting functions are generally unaffected, while mathematical functions appear to consistently respect the munged endpoints.

It is worth noting that Twix's set algebra functions (e.g. `Twix.intersection`) will currently always act on the `_trueStart` and `_trueEnd` values to create a mathematically-correct closed range, even if one of the source ranges was a half-open or fully open range.  This might be unintuitive for some formatting-centric use cases.

The default value of containEndpoints is `true`, for backward compatibility with previous versions of Twix.

This PR is largely motivated by our discussion in #44.  Sorry it took me so long to follow up on this!