### PR TITLE
Added the ability to specify showTime when formatting a range after it has been created.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules
 test/bin
 *.bak
 npm-debug.log
+
+#JetBrains IDE files
+.idea
+
+#Mac filesystem file
+.DS_Store

--- a/docs/docs.markdown
+++ b/docs/docs.markdown
@@ -545,7 +545,7 @@ Here are all the options and their defaults
   spaceBeforeMeridiem: true,
   showDate: true,
   showDayOfWeek: false,
-  showTime: false,
+  showTime: true,
   twentyFourHour: false,
   implicitMinutes: true,
   implicitYear: true,

--- a/docs/docs.markdown
+++ b/docs/docs.markdown
@@ -545,6 +545,7 @@ Here are all the options and their defaults
   spaceBeforeMeridiem: true,
   showDate: true,
   showDayOfWeek: false,
+  showTime: false,
   twentyFourHour: false,
   implicitMinutes: true,
   implicitYear: true,

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -278,6 +278,7 @@ makeTwix = (moment) ->
         spaceBeforeMeridiem: true
         showDate: true
         showDayOfWeek: false
+        showTime: true
         twentyFourHour: @localeData.twentyFourHour
         implicitMinutes: true
         implicitYear: true
@@ -351,14 +352,14 @@ makeTwix = (moment) ->
           pre: @_formatPre('dayOfWeek', options)
           slot: @_formatSlot('dayOfWeek')
 
-      if options.groupMeridiems && !options.twentyFourHour && !@allDay && !options.explicitAllDay
+      if options.groupMeridiems && !options.twentyFourHour && !@allDay && options.showTime
         fs.push
           name: "meridiem",
           fn: @_formatFn('meridiem', options)
           pre: @_formatPre('meridiem', options)
           slot: @_formatSlot('meridiem')
 
-      if !@allDay && !options.explicitAllDay
+      if !@allDay && options.showTime
         fs.push
           name: "time",
           fn: @_formatFn('time', options)

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -351,14 +351,14 @@ makeTwix = (moment) ->
           pre: @_formatPre('dayOfWeek', options)
           slot: @_formatSlot('dayOfWeek')
 
-      if options.groupMeridiems && !options.twentyFourHour && !@allDay
+      if options.groupMeridiems && !options.twentyFourHour && !@allDay && !options.explicitAllDay
         fs.push
           name: "meridiem",
           fn: @_formatFn('meridiem', options)
           pre: @_formatPre('meridiem', options)
           slot: @_formatSlot('meridiem')
 
-      if !@allDay
+      if !@allDay && !options.explicitAllDay
         fs.push
           name: "time",
           fn: @_formatFn('time', options)

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -1306,12 +1306,6 @@ test = (moment, Twix) ->
         options: {explicitAllDay: true}
         result: "all day May 25, 1982"
 
-      test "should show the dates but not times for multi day if explicit AllDay",
-        start: "2010-05-25 05:30"
-        end: "2010-05-27 06:30"
-        options: {explicitAllDay: true}
-        result: "May 25 - May 27, 2010"
-
     describe "no single dates", ->
       test "shouldn't show dates for intraday",
         start: "2010-05-25 05:30"
@@ -1325,12 +1319,25 @@ test = (moment, Twix) ->
         options: {showDate : false}
         result: "May 25, 5:30 AM - May 27, 6:30 AM"
 
-      test "should just say 'all day' for all day rangess",
+      test "should just say 'all day' for all day ranges",
         start: thisYear("05-25")
         end: thisYear("05-25")
         options: {showDate : false}
         allDay: true
         result: "all day"
+
+    describe "showTime includes time", ->
+      test "should show the dates and the times for multi day if showTime explicitly true",
+        start: "2010-05-25 05:30"
+        end: "2010-05-27 06:30"
+        result: "May 25, 5:30 AM - May 27, 6:30 AM, 2010"
+
+      test "should show the dates but not times for multi day if showTime false",
+        start: "2010-05-25 05:30"
+        end: "2010-05-27 06:30"
+        options: {showTime: false}
+        result: "May 25 - May 27, 2010"
+
 
     describe "ungroup meridiems", ->
       test "should put meridiems on both sides",

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -1306,6 +1306,12 @@ test = (moment, Twix) ->
         options: {explicitAllDay: true}
         result: "all day May 25, 1982"
 
+      test "should show the dates but not times for multi day if explicit AllDay",
+        start: "2010-05-25 05:30"
+        end: "2010-05-27 06:30"
+        options: {explicitAllDay: true}
+        result: "May 25 - May 27, 2010"
+
     describe "no single dates", ->
       test "shouldn't show dates for intraday",
         start: "2010-05-25 05:30"


### PR DESCRIPTION
Given:

```coffeescript
range = moment('2015-05-21 00:00').twix(moment('2015-05-25 23:59'))
```

Currently `range.format()` returns `May 21, 12 AM - May 25, 11:59 PM`.

This change allows you to specify `explicitAllDay: true` to the format function to remove the times.

For example, `range.format({explicitAllDay: true})` will return `May 21 - May 25`.

I found I had a range that I was doing operations on, and didn't want to recreate it just to format it in a specific instance.  




