### PR TITLE
Remove locale.js from Meteor package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,7 +17,6 @@ Package.onUse(function(api) {
   api.imply("momentjs:moment@2.10.6", where);
 
   api.add_files([
-    "dist/twix.js",
-    "dist/locale.js"
+    "dist/twix.js"
   ], where);
 });


### PR DESCRIPTION
`dist/locale.js` no longer exists as of 0.7.0. Because Meteor is trying to add this non-existent file, this version of the package currently doesn't work with Meteor.