### PR TITLE
meteor - updated package.js to point to README.md

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,7 +3,6 @@ Package.describe({
   summary: "Twix.js (official) by Isaac Cambron: a Moment.js plugin for working with date ranges.",
   version: "0.8.1",
   git: "https://github.com/icambron/twix.js.git",
-  documentation: "README.markdown",
 });
 
 // Makes Twix available both on the server and on the client


### PR DESCRIPTION
when not differently specified, the _documentation_ field defaults to `README.md`