### PR TITLE
Added ability to hide time and year during formatting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ test/coverage.html
 *.bak
 npm-debug.log
 .DS_Store
+
+#Jetbrains IDE files
+.idea
+*.iml

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -554,6 +554,18 @@ If you combine an all-day range with `showDate:false`, you get this:
 moment("2012-01-25").twix("2012-01-25", {allDay: true}).format({showDate: false}); //=> All day
 ```
 
+If you would like to hide the times for mutliple days you can use `showTime:false`:
+
+```js
+moment("2012-05-25T8:00").twix("2012-05-27T17:00").format({showTime: false}); //=> May 25 - May 27, 2012
+```
+
+If you would like to hide the year, specify `showYear:false`:
+
+```js
+moment("2012-05-25").twix("2012-05-27").format({showYear: false}); //=> May 25 - May 27
+```
+
 That text is customizable through the `allDay` option.
 
 ### All the options
@@ -566,6 +578,8 @@ Here are all the options and their defaults
   spaceBeforeMeridiem: true,
   showDate: true,
   showDayOfWeek: false,
+  showTime: true,
+  showYear: true,
   implicitMinutes: true,
   implicitYear: true,
   yearFormat: "YYYY",

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -217,6 +217,8 @@ makeTwix = (moment) ->
         spaceBeforeMeridiem: true
         showDate: true
         showDayOfWeek: false
+        showTime: true
+        showYear: true
         implicitMinutes: true
         implicitYear: true
         yearFormat: 'YYYY'
@@ -253,7 +255,7 @@ makeTwix = (moment) ->
           pre: ' '
           slot: 0
 
-      if needDate && (!options.implicitYear || @_start.year() != moment().year() || !@isSame('y'))
+      if needDate && options.showYear && (!options.implicitYear || @_start.year() != moment().year() || !@isSame('y'))
         fs.push
           name: 'year',
           fn: (date) -> date.format options.yearFormat
@@ -289,14 +291,14 @@ makeTwix = (moment) ->
           pre: ' '
           slot: 1
 
-      if options.groupMeridiems && needsMeridiem && !@allDay
+      if options.groupMeridiems && needsMeridiem && !@allDay && options.showTime
         fs.push
           name: 'meridiem',
           fn: (t) -> t.format options.meridiemFormat
           slot: 6
           pre: if options.spaceBeforeMeridiem then ' ' else ''
 
-      if !@allDay
+      if !@allDay && options.showTime
         fs.push
 
           name: 'time',

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -1257,6 +1257,12 @@ test = (moment, Twix) ->
         end: '1982-05-25 15:30'
         result: 'May 25, 1982, 5:30 AM - 3:30 PM'
 
+      test 'same day, different times shows date once and hides year if requested',
+        start: '1982-05-25 05:30'
+        end: '1982-05-25 15:30'
+        options: {showYear: false}
+        result: 'May 25, 5:30 AM - 3:30 PM'
+
       test 'same day, different times, same meridian shows date and meridiem once',
         start: '1982-05-25T05:30'
         end: '1982-05-25T06:30'
@@ -1364,6 +1370,12 @@ test = (moment, Twix) ->
         end: thisYear '05-27', '06:30'
         options: {showDate: false}
         result: 'May 25, 5:30 AM - May 27, 6:30 AM'
+
+      test 'should show the dates for multiday but hide times if requested',
+        start: thisYear '05-25', '05:30'
+        end: thisYear '05-27', '06:30'
+        options: {showDate: false, showTime: false}
+        result: 'May 25 - May 27'
 
       test "should just say 'all day' for all day rangess",
         start: thisYear('05-25')


### PR DESCRIPTION
Added a showTime formatting option, that when set to false will not show the time components.

For example, using the following:

```coffee
start = moment('2015-05-21 00:00:00')
end = moment('2015-05-23 11:59:00')

range = start.twix end

range.format
          dayFormat: 'Do'
          implicitMinutes: false
          groupMeridiems: false # May 21st, 12 AM - May 23rd, 11:59 AM, 2015
```

At the time of creation for my app, I do not know if the two date ranges are all day, so what this change does in the following:

```coffee
range.format
          dayFormat: 'Do'
          showTime: false # May 21st - May 23rd, 2015
```

Furthermore, by adding a showYear option, I can hide the year as well:

```coffee
range.format
          dayFormat: 'Do'
          showTime: false 
          showYear: false # May 21st - May 23rd
```

