### PR TITLE
best effort internationalization

### DIFF
--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -238,6 +238,9 @@ makeTwix = (moment) ->
 
       needsMeridiem = options.hourFormat && options.hourFormat[0] == 'h'
 
+      localFormat = @_start.localeData()._longDateFormat['L']
+      americanish = localFormat.indexOf('M') < localFormat.indexOf('D')
+
       goesIntoTheMorning =
         options.lastNightEndsAt > 0 &&
         !@allDay &&
@@ -261,13 +264,19 @@ makeTwix = (moment) ->
         fs.push
           name: 'year',
           fn: (date) -> date.format options.yearFormat
-          pre: ', '
+          pre: if americanish then ', ' else ' '
           slot: 4
 
       if atomicMonthDate && needDate
         fs.push
           name: 'month-date'
-          fn: (date) -> date.format "#{options.monthFormat} #{options.dayFormat}"
+          fn: (date) ->
+            format =
+              if americanish
+                "#{options.monthFormat} #{options.dayFormat}"
+              else
+                "#{options.dayFormat} #{options.monthFormat}"
+            date.format format
           ignoreEnd: -> goesIntoTheMorning
           pre: ' '
           slot: 2
@@ -277,14 +286,14 @@ makeTwix = (moment) ->
           name: 'month'
           fn: (date) -> date.format options.monthFormat
           pre: ' '
-          slot: 2
+          slot: if americanish then 2 else 3
 
       if !atomicMonthDate && needDate
         fs.push
           name: 'date'
           fn: (date) -> date.format options.dayFormat
           pre: ' '
-          slot: 3
+          slot: if americanish then 3 else 2
 
       if needDate && options.showDayOfWeek
         fs.push

--- a/test/twix.spec.coffee
+++ b/test/twix.spec.coffee
@@ -1540,15 +1540,26 @@ test = (moment, Twix) ->
       assertEqual '{start: 1982-05-25T00:00:00Z, end: 1982-05-25T00:00:00Z, allDay: true}', stringed
 
   describe 'internationalization', ->
-    it "uses the moment locale's 24-hour setting by default", ->
+
+    it 'shows the date in the right order', ->
+      start = moment('1982-05-25').locale 'en-gb'
+      range = start.twix(start.clone().add(1, 'hour'))
+      assertEqual '25 May 1982, 0:00 - 1:00', range.format()
+
+    it 'shows the date in the right order for all day ranges', ->
+      start = moment('1982-05-25').locale 'en-gb'
+      range = start.twix(start.clone().add(1, 'days'), allDay: true)
+      assertEqual '25 - 26 May 1982', range.format()
+
+    it "uses the moment locale's 24-hour setting", ->
       start = moment('1982-05-25').locale 'en-gb'
       range = start.twix(start.clone().add 1, 'days')
-      assertEqual 'May 25, 0:00 - May 26, 0:00, 1982', range.format()
+      assertEqual '25 May, 0:00 - 26 May, 0:00 1982', range.format()
 
-    it "uses the moment locale's settings by default", ->
+    it "uses the moment locale's month names", ->
       start = moment('1982-05-25').locale 'fr'
       range = start.twix(start.clone().add 1, 'days')
-      assertEqual 'mai 25, 0:00 - mai 26, 0:00, 1982', range.format()
+      assertEqual '25 mai, 0:00 - 26 mai, 0:00 1982', range.format()
 
 if define?
   define(['moment', 'twix'], (moment, Twix) -> test moment, Twix)


### PR DESCRIPTION
Replacement for #86. Because I'm like, all kinds of American, I don't actually know if these changes are right. Specifically, I'd love for someone to tell me if these would be right for your non-American locale (assuming "May" got translated and capitalized in a locally-appropriate way):
- 25 - 26 May 1982
- 25 May 1982, 0:00 - 1:00
- 25 May, 0:00 - 26 May, 1:00 1982

If so, I'll merge it and call it day. If not, I may do that anyway.

This probably won't fix Twix for all languages because it's conceptually kinda wrong. It _should_ parse the format and use that to build the collapsing rules, but last time I tried to do that, it didn't work so well. So this is a compromise between doing it right and not doing it at all.
