### PR TITLE
Extend existing moment instance before loading from dependencies

### DIFF
--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -455,7 +455,7 @@ makeTwix = (moment) ->
   Twix
 
 # -- MAKE AVAILABLE
-return module.exports = makeTwix(require 'moment') if hasModule
+return module.exports = makeTwix(if moment then return moment else require 'moment') if hasModule
 
 if typeof(define) == 'function' && define.amd
   define 'twix', ['moment'], (moment) -> makeTwix(moment)

--- a/src/twix.coffee
+++ b/src/twix.coffee
@@ -455,7 +455,7 @@ makeTwix = (moment) ->
   Twix
 
 # -- MAKE AVAILABLE
-return module.exports = makeTwix(if moment then return moment else require 'moment') if hasModule
+return module.exports = makeTwix(if moment? then moment else require 'moment') if hasModule
 
 if typeof(define) == 'function' && define.amd
   define 'twix', ['moment'], (moment) -> makeTwix(moment)


### PR DESCRIPTION
In a multi-plugin world `require 'moment'` leads to problems discussed in #102